### PR TITLE
Fix issues Default PID "D" setting outside of min / max range #24 and TEMP_LIMIT_HIGH is lower then max temperature setting #26

### DIFF
--- a/diyp-controller/dp_boiler.h
+++ b/diyp-controller/dp_boiler.h
@@ -12,7 +12,7 @@
 
 // Temperatures in [degC]
 #define TEMP_WINDOW 10.0      // in temperature range
-#define TEMP_LIMIT_HIGH 107.0 // > is TOO HGH
+#define TEMP_LIMIT_HIGH 108.0 // > is TOO HGH
 #define TEMP_LIMIT_LOW 1.0    // < is TOO LOW
 #define TEMP_MIN_BREW 10.0    // do not brew under this temp
 

--- a/diyp-controller/dp_settings.h
+++ b/diyp-controller/dp_settings.h
@@ -46,7 +46,7 @@ class DpSettings
         String serialize();
         int deserialize(String input);
         double temperature() { return settings.temperature; }
-        double temperature(double t) { return settings.temperature = min(110.0, max(t, 0.0)); }
+        double temperature(double t) { return settings.temperature = min(104.0, max(t, 0.0)); }
         double preInfusionTime() { return settings.preInfusionTime; }
         double preInfusionTime(double t) { return settings.preInfusionTime = min(60.0, max(t, 0.0)); }
         double infusionTime() { return settings.infusionTime; }
@@ -60,7 +60,7 @@ class DpSettings
         double I() { return settings.i; }
         double I(double i) { return settings.i = min(20.0, max(i, 0.00)); }
         double D() { return settings.d; }
-        double D(double d) { return settings.d = min(40.0, max(d, 0.0)); }
+        double D(double d) { return settings.d = min(100.0, max(d, 0.0)); }
         double ff_heat() { return settings.ff_heat; }
         double ff_heat(double ff) { return settings.ff_heat = min(100.0, max(ff, 0.0)); }
         double ff_ready() { return settings.ff_ready; }


### PR DESCRIPTION
Fix #24
Fix #26

Max temperature setting (from menu) is now 104 degrees, to match thermostat in machines.
TEMP_LIMIT_HIGH,  used for boiler to go into BOILER_ERROR_OVER_TEMP error, is now 108 degrees.