### PR TITLE
Issue41 Implement ## Summary Implements dynamic feed-forward factor control for improved brewing stabilitdynamic feed forward

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,9 @@
 
 name: Build
 
-on: [push]
+# on: [push]
+on:
+  workflow_dispatch:  # Only run manually
 
 jobs:
   build:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,8 @@
         "vector": "cpp",
         "string_view": "cpp",
         "memory": "cpp",
-        "initializer_list": "cpp"
+        "initializer_list": "cpp",
+        "cmath": "cpp"
     },
     "search.exclude": {
         "./src": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,13 @@
 {
-    "makefile.configureOnOpen": false
+    "makefile.configureOnOpen": false,
+    "files.associations": {
+        "array": "cpp",
+        "deque": "cpp",
+        "string": "cpp",
+        "unordered_map": "cpp",
+        "vector": "cpp",
+        "string_view": "cpp",
+        "memory": "cpp",
+        "initializer_list": "cpp"
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,11 @@
         "string_view": "cpp",
         "memory": "cpp",
         "initializer_list": "cpp"
+    },
+    "search.exclude": {
+        "./src": true
+    },
+    "C_Cpp.files.exclude" : {
+        "./src": true
     }
 }

--- a/AUTOTUNE.md
+++ b/AUTOTUNE.md
@@ -1,0 +1,173 @@
+# PID Auto-Tune Feature
+
+## Overview
+The auto-tune feature uses the Relay (Ziegler-Nichols) method to automatically determine optimal PID parameters for the boiler temperature control system.
+
+## How It Works
+
+### Relay Method
+1. **Relay Control**: Oscillates heater power between 0 and `relayAmplitude`
+2. **Peak Detection**: Tracks temperature peaks and valleys with noise band filtering (±0.15°C)
+3. **Period Calculation**: Measures oscillation period (Pu) from peak-to-peak timing
+4. **Gain Calculation**: Calculates ultimate gain (Ku) using formula: `Ku = (4 × d) / (π × a)`
+   - `d` = relay amplitude (typically 20%)
+   - `a` = oscillation amplitude (half of peak-to-valley difference)
+
+### Ziegler-Nichols Tuning Rules (Classic PID)
+- **Kp** = 0.6 × Ku
+- **Ki** = 1.2 × Ku / Pu  
+- **Kd** = 0.075 × Ku × Pu
+
+## Usage via Serial Commands
+
+### Start Auto-Tune
+```
+PUT boilerPidAutotune start           # Uses default relay amplitude (20%)
+```
+
+**Requirements:**
+- Boiler must be ON and in HEATING or READY state
+- Temperature must be stable (within 5°C of setpoint)
+
+### Monitor Progress
+```
+GET boilerPidAutotune
+```
+
+**Response states:**
+- `IDLE` - Not running
+- `RUNNING` - Collecting oscillation data
+- `SUCCESS` - Tuning completed successfully
+- `FAILED_TIMEOUT` - Timed out waiting for oscillations
+- `FAILED_NO_OSCILLATION` - Insufficient oscillation amplitude
+
+When SUCCESS, also returns:
+```
+state=SUCCESS
+Kp=12.345
+Ki=0.678
+Kd=90.123
+Ku=20.575
+Pu=45.230
+GET boilerPidAutotune OK
+```
+
+### Cancel Auto-Tune
+```
+PUT boilerPidAutotune cancel
+```
+Immediately stops auto-tune and returns to normal PID control.
+
+### Apply Results
+```
+PUT boilerPidAutotune apply
+```
+Applies the calculated PID parameters to the active controller. Only works if auto-tune completed successfully.
+
+## Parameters
+
+### Relay Amplitude
+- **Value**: 20% (defined by `AUTOTUNE_RELAY_OUTPUT`)
+- **Effect**: 
+  - Controls the magnitude of power oscillations
+  - Fixed value ensures consistent and predictable auto-tune behavior
+  - Can be changed by modifying the constant in `dp_pid.h` if needed
+
+### Setpoint Band
+- **Value**: ±0.5°C (defined by `AUTOTUNE_SETPOINT_BAND`)
+- **Purpose**: Hysteresis band around setpoint for relay switching (prevents chattering)
+
+### Peak Detection Noise Band
+- **Value**: ±0.15°C (defined by `AUTOTUNE_PEAK_NOISE_BAND`)
+- **Purpose**: Filters out measurement noise to avoid false peak detection during oscillations
+
+### Timeout
+- **Value**: 600 seconds (10 minutes) (defined by `AUTOTUNE_TIMEOUT_MS`)
+- **Purpose**: Prevents infinite loops if oscillations don't occur
+
+### Minimum Oscillations
+- **Value**: 3 complete cycles (defined by `AUTOTUNE_MIN_CYCLES`)
+- **Purpose**: Ensures stable period measurement
+
+## Implementation Details
+
+### Files Modified
+- `dp_pid.h` / `dp_pid.cpp`: Core auto-tune logic
+- `dp_boiler.h`: Wrapper methods for boiler controller
+- `dp_serial.h` / `dp_serial.cpp`: Serial command interface
+
+### Key Classes/Methods
+- `AutoTuneResults` struct: Holds Kp, Ki, Kd, Ku, Pu, isValid
+- `DpPID::startAutoTune()`: Initiates auto-tune with default relay amplitude
+- `DpPID::processAutoTune()`: Runs during each control cycle
+- `DpPID::getAutoTuneResults()`: Returns calculated parameters
+- `DpPID::cancelAutoTune()`: Stops auto-tune
+
+### State Machine
+```
+IDLE → RUNNING → SUCCESS
+            ↓
+    FAILED_TIMEOUT
+            ↓
+    FAILED_NO_OSCILLATION
+```
+
+## Best Practices
+
+1. **Start with stable temperature**: Let the boiler reach setpoint with existing PID before starting
+2. **Wait for completion**: Typical auto-tune takes 2-4 minutes
+3. **Review results**: Check that Kp, Ki, Kd values are reasonable before applying
+4. **Fine-tune if needed**: Ziegler-Nichols provides a good starting point but may need manual adjustment
+
+## Troubleshooting
+
+### Auto-Tune Won't Start
+- Check boiler is ON (`boilerController.is_on()`)
+- Check boiler is in valid state (HEATING or READY)
+- Check temperature is within 5°C of setpoint
+
+### Auto-Tune Times Out
+- Relay amplitude may be too small (adjust `AUTOTUNE_RELAY_OUTPUT` in `dp_pid.h` if needed)
+- System may have excessive lag
+- Check heater is responding correctly
+
+### Results Seem Wrong
+- Oscillations may not be stable
+- Try running auto-tune again
+- Check for external disturbances (brew cycle, etc.)
+- Consider adjusting `AUTOTUNE_RELAY_OUTPUT` in `dp_pid.h` if oscillations are consistently too large or too small
+
+## Example Session
+
+```
+# Start auto-tune
+PUT boilerPidAutotune start
+> PUT boilerPidAutotune OK, Auto-tune started
+
+# Monitor progress (repeat periodically)
+GET boilerPidAutotune
+> state=RUNNING
+> GET boilerPidAutotune OK
+
+# Wait for completion...
+GET boilerPidAutotune
+> state=SUCCESS
+> Kp=12.500
+> Ki=0.650
+> Kd=85.000
+> Ku=20.833
+> Pu=46.154
+> GET boilerPidAutotune OK
+
+# Apply the results
+PUT boilerPidAutotune apply
+> PUT boilerPidAutotune OK, Applied Kp=12.500 Ki=0.650 Kd=85.000
+```
+
+## Technical Notes
+
+- Auto-tune runs in the same control loop as normal PID (`DpPID::compute()`)
+- When auto-tune is active, normal PID calculation is bypassed
+- Peak detection uses rising/falling edge tracking with noise band hysteresis
+- Period is averaged over all detected oscillations for accuracy
+- Results are stored until next auto-tune or controller reset

--- a/diyp-controller/diyp-controller.ino
+++ b/diyp-controller/diyp-controller.ino
@@ -147,8 +147,10 @@ void print_state()
     Serial.print(brewProcess.end_weight());
     Serial.print(", reservoir_level:");
     Serial.print(reservoir.level());
+    Serial.print(", reservoir_weight:");
+    Serial.print(reservoir.weight());
 
-    dpSerial.send("");
+    Serial.println("");
     prev_time = millis();
   }
 }

--- a/diyp-controller/dp_boiler.cpp
+++ b/diyp-controller/dp_boiler.cpp
@@ -29,7 +29,7 @@ void BoilerStateMachine::state_heating()
 {
   ON_ENTRY()
   {
-    _pid.setFeedForward(_ff_heat, false);
+    _pid.setFeedForward(_ffHeat, false);
   }
   if (!_on)
     NEXT(state_off);
@@ -49,7 +49,7 @@ void BoilerStateMachine::state_ready()
 {
   ON_ENTRY()
   {
-    _pid.setFeedForward(_ff_ready, false);
+    _pid.setFeedForward(_ffReady, false);
   }
   if (!_on)
     NEXT(state_off);
@@ -69,7 +69,7 @@ void BoilerStateMachine::state_brew()
     NEXT(state_heating);
   ON_ENTRY()
   {
-    _pid.setFeedForward(_ff_ready, true); // TODO: ff_brew if dynamic feed forward disabled
+    _pid.setFeedForward(_ffReady, true);
   }
 
   // if ( (_set_temp - _act_temp ) > TEMP_WINDOW) goto_error(BOILER_ERROR_UNDER_TEMP);
@@ -99,7 +99,7 @@ void BoilerStateMachine::goto_error(boiler_error_t error)
 
 void BoilerStateMachine::init()
 {
-  _pid.begin(&_act_temp, &_power, &_set_temp, settings.P(), settings.I(), settings.D(), settings.ff_ready(), false, 1000, &reservoir); // get defaults from setting and set PID sample time to 1s (same as HeaterDevice)
+  _pid.begin(&_act_temp, &_power, &_set_temp, settings.P(), settings.I(), settings.D(), settings.ffReady(), false, 1000, &reservoir); // get defaults from setting and set PID sample time to 1s (same as HeaterDevice)
   _pid.setOutputLimits(0, 100);
   _pid.setWindUpLimits(WINDUP_LIMIT_MIN, WINDUP_LIMIT_MAX); // set bounds for the integral term to prevent integral wind-up
   _pid.start();

--- a/diyp-controller/dp_boiler.cpp
+++ b/diyp-controller/dp_boiler.cpp
@@ -183,8 +183,13 @@ void BoilerStateMachine::control(void)
   // Serial.print("/");
   // Serial.println(_pid2.D());
 
+  if (_power_control_mode == POWER_CONTROL_STATIC) {
+    _power = _power_static;
+  }
+
   if (_act_temp > (TEMP_LIMIT_HIGH + 2.0))
     _power = 0;
+
   heaterDevice.power(_on ? _power : 0.0);
 #ifdef WATCHDOG_ENABLED
   wdt_reset();
@@ -228,4 +233,31 @@ const char *BoilerStateMachine::get_state_name()
   RETURN_STATE_NAME(error);
   RETURN_NONE_STATE_NAME()
   RETURN_UNKNOWN_STATE_NAME();
+}
+
+bool BoilerStateMachine::set_power_control_mode_str(String mode)
+{
+  mode.trim();
+  mode.toUpperCase();
+  
+  if (mode == "PID") {
+    _power_control_mode = POWER_CONTROL_PID;
+    return true;
+  } else if (mode == "STATIC") {
+    _power_control_mode = POWER_CONTROL_STATIC;
+    return true;
+  }
+  return false; // Invalid mode
+}
+
+String BoilerStateMachine::get_power_control_mode_str() const
+{
+  switch (_power_control_mode) {
+    case POWER_CONTROL_PID:
+      return "PID";
+    case POWER_CONTROL_STATIC:
+      return "STATIC";
+    default:
+      return "UNKNOWN";
+  }
 }

--- a/diyp-controller/dp_boiler.cpp
+++ b/diyp-controller/dp_boiler.cpp
@@ -8,13 +8,14 @@
 #include "dp_boiler.h"
 #include "dp_heater.h"
 #include "dp_settings.h"
-
+#include "dp_brew.h"
 //#include <Adafruit_MAX31865.h>
 
 #ifdef WATCHDOG_ENABLED
 #include <wdt_samd21.h>
 #endif
 
+#define _DP_FSM_TYPE BoilerStateMachine
 BoilerStateMachine boilerController = BoilerStateMachine();
 
 void BoilerStateMachine::state_off()
@@ -28,7 +29,7 @@ void BoilerStateMachine::state_heating()
 {
   ON_ENTRY()
   {
-    _pid.setFeedForward(_ff_heat);
+    _pid.setFeedForward(_ff_heat, false);
   }
   if (!_on)
     NEXT(state_off);
@@ -40,7 +41,7 @@ void BoilerStateMachine::state_heating()
   goto_error(BOILER_ERROR_TIMEOUT_HEATING);
   ON_EXIT()
   {
-    _pid.setFeedForward(0);
+    _pid.setFeedForward(0, false);
   }
 }
 
@@ -48,7 +49,7 @@ void BoilerStateMachine::state_ready()
 {
   ON_ENTRY()
   {
-    _pid.setFeedForward(_ff_ready);
+    _pid.setFeedForward(_ff_ready, false);
   }
   if (!_on)
     NEXT(state_off);
@@ -68,7 +69,7 @@ void BoilerStateMachine::state_brew()
     NEXT(state_heating);
   ON_ENTRY()
   {
-    _pid.setFeedForward(_ff_brew);
+    _pid.setFeedForward(_ff_ready, true); // TODO: ff_brew if dynamic feed forward disabled
   }
 
   // if ( (_set_temp - _act_temp ) > TEMP_WINDOW) goto_error(BOILER_ERROR_UNDER_TEMP);
@@ -76,7 +77,7 @@ void BoilerStateMachine::state_brew()
   goto_error(BOILER_ERROR_TIMEOUT_BREW);
   ON_EXIT()
   {
-    _pid.setFeedForward(0);
+    _pid.setFeedForward(0, false);
     _brew = false;
   }
 }
@@ -98,7 +99,7 @@ void BoilerStateMachine::goto_error(boiler_error_t error)
 
 void BoilerStateMachine::init()
 {
-  _pid.begin(&_act_temp, &_power, &_set_temp, settings.P(), settings.I(), settings.D(), settings.ff_ready(), 1000); // get defaults from setting and set PID sample time to 1s (same as HeaterDevice)
+  _pid.begin(&_act_temp, &_power, &_set_temp, settings.P(), settings.I(), settings.D(), settings.ff_ready(), false, 1000, &reservoir); // get defaults from setting and set PID sample time to 1s (same as HeaterDevice)
   _pid.setOutputLimits(0, 100);
   _pid.setWindUpLimits(WINDUP_LIMIT_MIN, WINDUP_LIMIT_MAX); // set bounds for the integral term to prevent integral wind-up
   _pid.start();

--- a/diyp-controller/dp_boiler.cpp
+++ b/diyp-controller/dp_boiler.cpp
@@ -124,14 +124,22 @@ void BoilerStateMachine::begin()
 
 void BoilerStateMachine::control(void)
 {
-
-  //unsigned long start_time = millis();
-  //_act_temp = thermistor.temperature(RNOMINAL, RREF);
-  _act_temp = thermistor.getTemperature(RNOMINAL, RREF);
+  double raw_temp = thermistor.getTemperature(RNOMINAL, RREF);
 
 #ifdef SIMULATE
-  _act_temp = heaterDevice.average(); // hack for testing, read average power as actual temperature
+  raw_temp = heaterDevice.average(); // hack for testing, read average power as actual temperature
 #endif
+
+  // Apply Exponential Moving Average filter to filter out noise and smooth the temperature readings.
+  if (!_temp_initialized) {
+    _act_temp = raw_temp;
+    _temp_initialized = true;
+  } else {
+    _act_temp = (TEMP_FILTER_ALPHA * raw_temp) + ((1.0 - TEMP_FILTER_ALPHA) * _act_temp);
+  }
+
+  // Serial.print("Raw Temp: "); Serial.print(raw_temp);
+  // Serial.print(" °C, Filtered Temp: "); Serial.print(_act_temp); Serial.println(" °C");
 
   //_rtd_error = thermistor.readFault();
   _rtd_error = thermistor.getFault();
@@ -155,33 +163,6 @@ void BoilerStateMachine::control(void)
   run();
 
   _pid.compute();
-
-  // char buffer[10];
-  // Serial.print("Diff: ");
-  // snprintf(buffer, sizeof(buffer), "%6.1f", _power2 - _power);
-  // Serial.print(buffer);
-  // Serial.print("PID1: ");
-  // snprintf(buffer, sizeof(buffer), "%6.1f", _power);
-  // Serial.print(buffer);
-  // Serial.print(" PID2: ");
-  // snprintf(buffer, sizeof(buffer), "%6.1f", _power2);
-  // Serial.print(buffer);
-  // Serial.print(" Temp: ");
-  // Serial.print(_act_temp);
-  // Serial.print("/");
-  // Serial.print(_set_temp);
-  // Serial.print(" P: ");
-  // Serial.print(_pid.P());
-  // Serial.print("/");
-  // Serial.print(_pid2.P());
-  // Serial.print(" I: ");
-  // Serial.print(_pid.I());
-  // Serial.print("/");
-  // Serial.print(_pid2.I());
-  // Serial.print(" D: ");
-  // Serial.print(_pid.D());
-  // Serial.print("/");
-  // Serial.println(_pid2.D());
 
   if (_power_control_mode == POWER_CONTROL_STATIC) {
     _power = _power_static;

--- a/diyp-controller/dp_boiler.h
+++ b/diyp-controller/dp_boiler.h
@@ -120,7 +120,7 @@ private:
   int _rtd_error = 0;   // current RTD errors
   
   // Temperature filter (EMA)
-  static constexpr double TEMP_FILTER_ALPHA = 0.25; // 0-1, lower = more filtering
+  static constexpr double TEMP_FILTER_ALPHA = 0.15; // 0-1, lower = more filtering
   bool _temp_initialized = false;
   void state_off();     // SSR is forced OFF
   void state_heating(); // Temperature control, but not yet on target temperature

--- a/diyp-controller/dp_boiler.h
+++ b/diyp-controller/dp_boiler.h
@@ -5,11 +5,13 @@
 #ifndef BOILER_H
 #define BOILER_H
 
-#define _DP_FSM_TYPE BoilerStateMachine // used for the state machine macro NEXT()
 #include "dp_hardware.h"
+
+#define _DP_FSM_TYPE BoilerStateMachine // used for the state machine macro NEXT()
 #include "dp_fsm.h"
 #include "dp_pid.h"
 #include "dp_heater.h"
+#include "dp_reservoir.h"
 #include <Arduino.h>
 
 #include <MAX31865_NonBlocking.h> 
@@ -64,6 +66,8 @@ public:
   double set_ff_brew(double ff) { return _ff_brew = min(100.0, max(ff, 0.0)); }
   double get_ff_brew(void) { return _ff_brew; }
   void set_pid(double p, double i, double d) { _pid.setCoefficients(p, i, d); }
+  bool get_serial_output() const { return _pid.getSerialOutput(); }
+  void set_serial_output(const bool& enabled) { _pid.setSerialOutput(enabled); }
   void on() { _on = true; }
   void off()
   {

--- a/diyp-controller/dp_boiler.h
+++ b/diyp-controller/dp_boiler.h
@@ -49,6 +49,13 @@ typedef enum
   BOILER_ERROR_UNKNOWN,
 } boiler_error_t;
 
+// Power control modes
+typedef enum
+{
+  POWER_CONTROL_PID,    // PID controller (default)
+  POWER_CONTROL_STATIC, // Static power output
+} power_control_mode_t;
+
 class BoilerStateMachine : public StateMachine<BoilerStateMachine>
 {
 public:
@@ -68,6 +75,22 @@ public:
   void set_pid(double p, double i, double d) { _pid.setCoefficients(p, i, d); }
   bool get_serial_output() const { return _pid.getSerialOutput(); }
   void set_serial_output(const bool& enabled) { _pid.setSerialOutput(enabled); }
+
+  void set_power_control_mode(power_control_mode_t mode) { _power_control_mode = mode; }
+  bool set_power_control_mode_str(String mode);
+  power_control_mode_t get_power_control_mode() const { return _power_control_mode; }
+  String get_power_control_mode_str() const;
+  void reset_power_control_mode() { _power_control_mode = POWER_CONTROL_PID; }
+
+  void set_power_static(double power) { _power_static = min(100.0, max(power, 0.0)); };
+  double get_power_static() const { return _power_static; };
+
+  // Auto-tune methods
+  void startAutoTune() { return _pid.startAutoTune(); }
+  void cancelAutoTune() { _pid.cancelAutoTune(); }
+  autotune_state_t getAutoTuneState() const { return _pid.getAutoTuneState(); }
+  AutoTuneResults getAutoTuneResults() const { return _pid.getAutoTuneResults(); }
+  
   void on() { _on = true; }
   void off()
   {
@@ -90,6 +113,8 @@ private:
   DpPID _pid;
   double _act_temp = 0, _set_temp = 0, _ff_heat = 0, _ff_ready = 0, _ff_brew = 0, _power = 0;
   bool _on = false, _brew = false;
+  power_control_mode_t _power_control_mode = POWER_CONTROL_PID;
+  double _power_static = 0.0;
   unsigned long _last_control_time = 0;
   boiler_error_t _error = BOILER_ERROR_NONE;
   int _rtd_error = 0;   // current RTD errors

--- a/diyp-controller/dp_boiler.h
+++ b/diyp-controller/dp_boiler.h
@@ -118,6 +118,10 @@ private:
   unsigned long _last_control_time = 0;
   boiler_error_t _error = BOILER_ERROR_NONE;
   int _rtd_error = 0;   // current RTD errors
+  
+  // Temperature filter (EMA)
+  static constexpr double TEMP_FILTER_ALPHA = 0.25; // 0-1, lower = more filtering
+  bool _temp_initialized = false;
   void state_off();     // SSR is forced OFF
   void state_heating(); // Temperature control, but not yet on target temperature
   void state_ready();   // temperature control, within range of target temperature

--- a/diyp-controller/dp_boiler.h
+++ b/diyp-controller/dp_boiler.h
@@ -66,12 +66,11 @@ public:
   double set_temp(double temp) { return _set_temp = min(TEMP_LIMIT_HIGH, max(temp, 0.0)); }
   double act_temp() { return _act_temp; }
   double act_power() { return _power; }
-  double set_ff_heat(double ff) { return _ff_heat = min(100.0, max(ff, 0.0)); }
-  double get_ff_heat(void) { return _ff_heat; }
-  double set_ff_ready(double ff) { return _ff_ready = min(100.0, max(ff, 0.0)); }
-  double get_ff_ready(void) { return _ff_ready; }
-  double set_ff_brew(double ff) { return _ff_brew = min(100.0, max(ff, 0.0)); }
-  double get_ff_brew(void) { return _ff_brew; }
+  double set_ffHeat(double ff) { return _ffHeat = min(100.0, max(ff, 0.0)); }
+  double get_ffHeat(void) { return _ffHeat; }
+  double set_ffReady(double ff) { return _ffReady = min(100.0, max(ff, 0.0)); }
+  double get_ffReady(void) { return _ffReady; }
+  void set_dffFactorPct(double factorPct) { _pid.setDynamicFeedForwardFactorPct(factorPct); } 
   void set_pid(double p, double i, double d) { _pid.setCoefficients(p, i, d); }
   bool get_serial_output() const { return _pid.getSerialOutput(); }
   void set_serial_output(const bool& enabled) { _pid.setSerialOutput(enabled); }
@@ -111,7 +110,7 @@ public:
 
 private:
   DpPID _pid;
-  double _act_temp = 0, _set_temp = 0, _ff_heat = 0, _ff_ready = 0, _ff_brew = 0, _power = 0;
+  double _act_temp = 0, _set_temp = 0, _ffHeat = 0, _ffReady = 0, _power = 0;
   bool _on = false, _brew = false;
   power_control_mode_t _power_control_mode = POWER_CONTROL_PID;
   double _power_static = 0.0;

--- a/diyp-controller/dp_brew.cpp
+++ b/diyp-controller/dp_brew.cpp
@@ -13,6 +13,7 @@
 #include "dp_settings.h"
 #include "dp_brew.h"
 
+#define _DP_FSM_TYPE BrewProcess
 BrewProcess brewProcess = BrewProcess();
 
 // Check common state transitions (commissioning, brewing, empty)
@@ -165,6 +166,7 @@ void BrewProcess::state_idle()
     NEXT(state_init);
 }
 
+// Warning state before brewing when reservoir is almost empty
 void BrewProcess::state_warning_pre_brew()
 {
   ON_ENTRY()

--- a/diyp-controller/dp_display.cpp
+++ b/diyp-controller/dp_display.cpp
@@ -76,6 +76,11 @@ void format_float(char *dest, double f, int digits, int len)
 {
   bool neg = f < 0;
   if ( neg ) f *= -1.0;
+  
+  // Round to the specified number of decimal places
+  double multiplier = pow(10.0, digits);
+  f = round(f * multiplier) / multiplier;
+  
   char sign[2] = {'-', 0};
   if ( !neg )
     sign[0] = 0;

--- a/diyp-controller/dp_menu.cpp
+++ b/diyp-controller/dp_menu.cpp
@@ -38,11 +38,11 @@ const setting_t settings_list[] =
         {"P-Gain", "%/\337C", &settings_vals[5], 0.2, 1},
         {"I-Gain", "%/\337C/s", &settings_vals[6], 0.01, 2},
         {"D-Gain", "%s", &settings_vals[7], 1, 0},
-        {"FF-heat Value", "%", &settings_vals[8], 0.2, 1},
-        {"FF-ready Value", "%", &settings_vals[9], 0.2, 1},
-        {"FF-brew Value", "%", &settings_vals[10], 0.2, 1},
+        {"DFF Factor", "%", &settings_vals[8], 0.5, 1},
+        {"FF heat Value", "%", &settings_vals[9], 0.2, 1},
+        {"FF ready Value", "%", &settings_vals[10], 0.2, 1},
         {"Shot counter", "shots", &settings_vals[11], READ_ONLY, 0},
-        {"WIFI Mode", "OFF\0ON\0CONFIG-AP\0", &settings_vals[12], SELECT_ITEM, 1},
+        {"WIFI mode", "OFF\0ON\0CONFIG-AP\0", &settings_vals[12], SELECT_ITEM, 1},
         {"Weight trim", "%", &settings_vals[13], 0.05, 2},
         {"Commissioning done", "NO\0YES\0", &settings_vals[14], SELECT_ITEM, 1},
         {"   <Tare Weight>", "FULL", &settings_vals[31], EXECUTE_FUNCTION, FUNCTION_TARE},
@@ -365,9 +365,9 @@ int menu_settings(bool button_pressed)
 double add_value(int n, double delta)
 {
   double result;
-  if (delta != 0)
-    Serial.print("delta:");
-  Serial.print(delta);
+  // if (delta != 0)
+  //   Serial.print("delta:");
+  // Serial.print(delta);
 
   switch (n)
   {
@@ -388,11 +388,11 @@ double add_value(int n, double delta)
   case 7:
     return settings.D(settings.D() + delta);
   case 8:
-    return settings.ff_heat(settings.ff_heat() + delta);
+    return settings.dffFactorPct(settings.dffFactorPct() + delta);
   case 9:
-    return settings.ff_ready(settings.ff_ready() + delta);
+    return settings.ffHeat(settings.ffHeat() + delta);
   case 10:
-    return settings.ff_brew(settings.ff_brew() + delta);
+    return settings.ffReady(settings.ffReady() + delta);
   case 11:
     return settings.shotCounter();
   case 12:

--- a/diyp-controller/dp_menu.cpp
+++ b/diyp-controller/dp_menu.cpp
@@ -37,7 +37,7 @@ const setting_t settings_list[] =
         {"Extraction weight", "gram", &settings_vals[4], 0.5, 2},
         {"P-Gain", "%/\337C", &settings_vals[5], 0.2, 1},
         {"I-Gain", "%/\337C/s", &settings_vals[6], 0.01, 2},
-        {"D-Gain", "%s", &settings_vals[7], 0.2, 1},
+        {"D-Gain", "%s", &settings_vals[7], 1, 0},
         {"FF-heat Value", "%", &settings_vals[8], 0.2, 1},
         {"FF-ready Value", "%", &settings_vals[9], 0.2, 1},
         {"FF-brew Value", "%", &settings_vals[10], 0.2, 1},

--- a/diyp-controller/dp_pid.cpp
+++ b/diyp-controller/dp_pid.cpp
@@ -191,6 +191,20 @@ void DpPID::setFeedForward(const double &staticFeedForward, const bool &dynamicF
     this->dynamicFeedForwardEnabled = dynamicFeedForwardEnabled;
 }
 
+/**
+ * @brief Sets the dynamic feed-forward factor for the PID controller. 
+ * This factor influences how aggressively the controller responds to changes in
+ * reservoir weight and can be used to prevent overshoot.
+ * This method converts a percentage value to a normalized factor and stores it.
+ * 
+ * @param factor The feed-forward factor as a percentage (0-100).
+ *               Values outside this range will be clamped to the nearest valid value.
+ */
+void DpPID::setDynamicFeedForwardFactorPct(const double &factor)
+{
+    dffFactor = constrain(factor / 100.0, 0.0, 2.0); // convert percentage to factor
+}
+
 /// @brief Set the sample time for the PID controller
 /// @param minSamplePeriodMs the minimum sample period in milliseconds
 void DpPID::setSampleTime(const unsigned int &minSamplePeriodMs)

--- a/diyp-controller/dp_pid.cpp
+++ b/diyp-controller/dp_pid.cpp
@@ -129,10 +129,10 @@ double DpPID::calculateFeedForward()
             // Serial.println(deltaWeight, 2);
 
             // Update the energy stock pile
-            dffEnergyStockPile += deltaWeight * SPECIFIC_HEAT_CAPACITY_WATER * ( *setpoint - reservoir->outflowTemp()) * dffRatio; // in Joules
+            dffEnergyStockPile += deltaWeight * SPECIFIC_HEAT_CAPACITY_WATER * ( *setpoint - reservoir->outflowTemp()) * dffFactor; // in Joules
             dffEnergyStockPile = constrain(dffEnergyStockPile, 0.0, DFF_ENERGY_STOCK_PILE_MAX_MS * boilerPowerKiloWatt); // limit the energy stock pile
 
-            Serial.print("energy stock pile (kJ): ");
+            // Serial.print("energy stock pile (kJ): ");
             // Serial.println(dffEnergyStockPile / 1000.0, 2);
         }
 

--- a/diyp-controller/dp_pid.cpp
+++ b/diyp-controller/dp_pid.cpp
@@ -7,25 +7,43 @@
 /// @param p the coefficient for the proportional term
 /// @param i the coefficient for the integral term
 /// @param d the coefficient for the derivative term
-/// @param feedForward the feed forward term
+/// @param staticFeedForward the static feed forward term
 /// @param minSamplePeriodMs the minimum sample period in milliseconds
+/// @param reservoir pointer to the reservoir object to get weight for dynamic feed forward
+/// @param brewProcess pointer to the brew process object to check if brewing for dynamic feed forward
 void DpPID::begin(double *input, double *output, double *setpoint, 
              const double &p, const double &i, const double &d, 
-             const double &feedForward, const unsigned int &minSamplePeriodMs)
+             const double &staticFeedForward, const bool &dynamicFeedForwardEnabled, const unsigned int &minSamplePeriodMs,
+             Reservoir *reservoir)
 {
     this->input = input;
     this->output = output;
     this->setpoint = setpoint;
+    this->reservoir = reservoir;
 
     this->setCoefficients(p, i, d);
 
-    this->setFeedForward(feedForward);
+    this->setFeedForward(staticFeedForward, dynamicFeedForwardEnabled);
     this->setSampleTime(minSamplePeriodMs);
+
+    lastTime = millis();
+    curSampleTimeMs = 0;
+
+    this->previousReservoirWeight = reservoir ? reservoir->weight() : 0;
+    this->dffEnergyStockPile = 0;
+
 }
 
 void DpPID::start()
 {
-    reset();
+    lastError = 0;
+    lastInput = *input;
+    lastSetpoint = *setpoint;
+
+    lastTime = millis();
+
+    this->previousReservoirWeight = reservoir ? reservoir->weight() : 0;
+    this->dffEnergyStockPile = 0;
 }
 
 void DpPID::reset()
@@ -43,6 +61,11 @@ void DpPID::reset()
 
     lastTime = millis();
     curSampleTimeMs = 0;
+
+    dynamicFeedForward = 0;
+    dynamicFeedForwardEnabled = false;
+    this->previousReservoirWeight = reservoir ? reservoir->weight() : 0;
+    this->dffEnergyStockPile = 0;
 }
 
 void DpPID::compute()
@@ -58,12 +81,6 @@ void DpPID::compute()
         termP = Kp * curError; // Kp time the error in temperature.
 
         // integral term
-        #ifdef PID_DEBUG
-            Serial.print("curError: ");
-            Serial.print(curError);
-            Serial.print("lastError: ");
-            Serial.println(lastError);
-        #endif
         termI = termI + Ki * (curSampleTimeMs / 1000.0) * (curError + lastError) / 2.0; // trapezoidal integration: sum of the error over time.
         termI = constrain(termI, windUpMin, windUpMax); // prevent integral wind-up
 
@@ -71,7 +88,8 @@ void DpPID::compute()
         termD = Kd * -1 * dInput * 1000.0 / curSampleTimeMs;
 
 
-        unconstrainedOutput = feedForward + termP + termI + termD;
+
+        unconstrainedOutput = calculateFeedForward() + termP + termI + termD;
         *output = constrain(unconstrainedOutput, outputMin, outputMax);
 
         lastInput = *input;
@@ -79,11 +97,56 @@ void DpPID::compute()
         lastError = curError;
         lastTime = now;
 
-    #ifdef PID_DEBUG
-        printToSerial();
-    #endif
+        if (serialOutput) {
+            printToSerial();
+        }
     }
 }
+
+double DpPID::calculateFeedForward()
+{
+    if (reservoir == nullptr) return staticFeedForward;
+
+    double currentWeight = reservoir->weight();
+
+    // Reduce the energy stock pile with previous dynamic feed forward and actual time passed, decay the stock pile as well.
+    dffEnergyStockPile -= dynamicFeedForward * curSampleTimeMs * boilerPowerKiloWatt / 100.0; // in Joules
+    dffEnergyStockPile = max(dffEnergyStockPile, 0.0); // don't allow negative stock pile
+    dffEnergyStockPile = dffEnergyStockPile * DFF_ENERGY_STOCK_PILE_DECAY; // decay the energy stock pile
+
+    if (curSampleTimeMs < 1 || *setpoint <= reservoir->outflowTemp()) {
+        dynamicFeedForward = 0;
+    } else {
+        double deltaWeight = previousReservoirWeight - currentWeight; // Reservoir weight decreases when water is flowing in the boiler
+
+        if(this->dynamicFeedForwardEnabled || (long)(this->lastTime - this->lastDynamicFeedForwardTime < 0)) { // only increase stock pile when dynamic feed forward is enabled (typically when pump is on) or was enabled during last cycle
+
+            // delta weight is limited to the maximum flow rate and should be > 0
+            deltaWeight = constrain(deltaWeight, 0, MAX_FLOW_RATE_G_PER_MS * curSampleTimeMs);
+
+            // Serial.println();
+            // Serial.print("deltaWeight (g): ");
+            // Serial.println(deltaWeight, 2);
+
+            // Update the energy stock pile
+            dffEnergyStockPile += deltaWeight * SPECIFIC_HEAT_CAPACITY_WATER * ( *setpoint - reservoir->outflowTemp()) * dffRatio; // in Joules
+            dffEnergyStockPile = constrain(dffEnergyStockPile, 0.0, DFF_ENERGY_STOCK_PILE_MAX_MS * boilerPowerKiloWatt); // limit the energy stock pile
+
+            Serial.print("energy stock pile (kJ): ");
+            // Serial.println(dffEnergyStockPile / 1000.0, 2);
+        }
+
+        // Calculate the feed forward power request
+        dynamicFeedForward = 100 * dffEnergyStockPile / (curSampleTimeMs * boilerPowerKiloWatt); // in percentage of boiler power
+        dynamicFeedForward = constrain(dynamicFeedForward, 0, (100 - staticFeedForward));
+    }
+
+    // Update the previous reservoir weight
+    previousReservoirWeight = currentWeight;
+
+    return dynamicFeedForward + staticFeedForward;
+}
+
 
 void DpPID::setOutputLimits(const double &min, const double &max)
 {
@@ -110,9 +173,15 @@ void DpPID::setCoefficients(const double &p, const double &i, const double &d)
     Kd = d;
 }
 
-void DpPID::setFeedForward(const double &feedForward)
+void DpPID::setFeedForward(const double &staticFeedForward, const bool &dynamicFeedForwardEnabled)
 {
-    this->feedForward = feedForward;
+    this->staticFeedForward = constrain(staticFeedForward, 0.0, 100.0);
+
+    if (this->dynamicFeedForwardEnabled && !dynamicFeedForwardEnabled) {
+        // Dynamic feed forward is being disabled, store last dynamic feed forward time
+        this->lastDynamicFeedForwardTime = millis();
+    }
+    this->dynamicFeedForwardEnabled = dynamicFeedForwardEnabled;
 }
 
 /// @brief Set the sample time for the PID controller
@@ -124,32 +193,38 @@ void DpPID::setSampleTime(const unsigned int &minSamplePeriodMs)
 
 void DpPID::printToSerial()
 {
+    Serial.print("DP_PID_STATE ");
     Serial.print("input: ");
     Serial.print(*input);
     Serial.print(", setpoint: ");
     Serial.print(*setpoint);
-    Serial.print(", P: ");
+    Serial.print(", termP: ");
     Serial.print(termP);
-    Serial.print(", I: ");
+    Serial.print(", termI: ");
     Serial.print(termI);
-    Serial.print(", D: ");
+    Serial.print(", termD: ");
     Serial.print(termD);
-    Serial.print(", FF: ");
-    Serial.print(feedForward);
-    Serial.print(", Output: ");
+    Serial.print(", sFF: ");
+    Serial.print(staticFeedForward);
+    Serial.print(", dFF: ");
+    Serial.print(dynamicFeedForward);
+    Serial.print(", output: ");
     Serial.print(*output);
-    Serial.print(", Unconstrained Output: ");
-    Serial.println(unconstrainedOutput);
-
-    Serial.print("Kp: ");
+    Serial.print(", unconstrainedOutput: ");
+    Serial.print(unconstrainedOutput);
+    Serial.print(", Kp: ");
     Serial.print(Kp);
     Serial.print(", Ki: ");
     Serial.print(Ki);
     Serial.print(", Kd: ");
     Serial.print(Kd);
-    Serial.print(", Windup Min: ");
+    Serial.print(", windupMin: ");
     Serial.print(windUpMin);
-    Serial.print(", Windup Max: ");
-    Serial.println(windUpMax);
-
+    Serial.print(", windupMax: ");
+    Serial.print(windUpMax);
+    Serial.print(", stockPileKJ): ");
+    Serial.print(dffEnergyStockPile / 1000.0, 2);
+    Serial.print(", prevWeight: ");
+    Serial.println(previousReservoirWeight);
+    
 }

--- a/diyp-controller/dp_pid.cpp
+++ b/diyp-controller/dp_pid.cpp
@@ -69,11 +69,18 @@ void DpPID::reset()
 }
 
 void DpPID::compute()
-{
+{  
     unsigned long now = millis();
     curSampleTimeMs = now - lastTime;
     if (curSampleTimeMs >= minSamplePeriodMs) // check if enough time has passed, minSamplePeriodMs can't be < 1ms
     {
+        // If auto-tuning is running, process auto-tune instead of normal PID
+        if (autotuneState == AUTOTUNE_RUNNING) {
+            processAutoTune();
+            lastTime = now; // Update lastTime to avoid large jumps after autotune
+            return;
+        }
+
         curError = *setpoint - *input; // temp diff between setpoint and actual
         double dInput = *input - lastInput; // the change in temperature
 
@@ -215,7 +222,7 @@ void DpPID::printToSerial()
     Serial.print(", Kp: ");
     Serial.print(Kp);
     Serial.print(", Ki: ");
-    Serial.print(Ki);
+    Serial.print(Ki, 4);
     Serial.print(", Kd: ");
     Serial.print(Kd);
     Serial.print(", windupMin: ");
@@ -228,3 +235,251 @@ void DpPID::printToSerial()
     Serial.println(previousReservoirWeight);
     
 }
+
+// ============================================================================
+// Auto-Tune Implementation (Relay Method / Ziegler-Nichols)
+// ============================================================================
+
+void DpPID::startAutoTune()
+{
+
+    Serial.println("=== Starting Auto-tune ===");
+    Serial.print("Auto-tune Setpoint: ");
+    Serial.print(*setpoint);
+    Serial.println("°C");
+    Serial.print("Relay amplitude: ");
+    Serial.print(AUTOTUNE_RELAY_OUTPUT);
+    Serial.println("%");
+    Serial.print("Setpoint band: ");
+    Serial.print(AUTOTUNE_SETPOINT_BAND);
+    Serial.println("°C");
+    Serial.print("Peak detection noise band: ");
+    Serial.print(AUTOTUNE_PEAK_NOISE_BAND);
+    Serial.println("°C");
+
+    //TODO: only start if temperature is within the band of the setpoint
+
+    autotuneState = AUTOTUNE_RUNNING;
+    autotuneStartTime = millis();
+    
+    // Initialize auto-tune results
+    autotuneResults = AutoTuneResults(); // Reset to defaults
+    
+    // Initialize tracking variables
+    atRelayState = false;
+    atPeakHigh = *input;
+    atPeakLow = *input;
+    atPeakCount = 0;
+    atLastValue = *input;
+    atRisingEdge = true;
+    
+    // Clear peak times array
+    for (int i = 0; i < 10; i++) {
+        atPeakTimes[i] = 0;
+    }
+    
+    // Start with relay ON to begin oscillations
+    *output = AUTOTUNE_RELAY_OUTPUT;
+    atRelayState = true;
+    
+    if (serialOutput) {
+        Serial.println("Auto-tune initialized successfully");
+    }
+}
+
+void DpPID::cancelAutoTune()
+{
+    if (serialOutput) {
+        Serial.println("Auto-tune cancelled");
+    }
+    
+    autotuneState = AUTOTUNE_IDLE;
+    *output = 0; // Turn power off
+
+    Serial.println("=== Auto-tune cancelled ===");
+}
+
+AutoTuneResults DpPID::getAutoTuneResults() const
+{
+    return autotuneResults;
+}
+
+void DpPID::processAutoTune()
+{
+    // Check for timeout
+    if ((millis() - autotuneStartTime) > AUTOTUNE_TIMEOUT_MS) {
+        autotuneState = AUTOTUNE_FAILED_TIMEOUT;
+        *output = 0;
+        if (serialOutput) {
+            Serial.println("=== Auto-tune FAILED: Timeout ===");
+        }
+        return;
+    }
+
+    double inputValue = *input;
+    double error = *setpoint - inputValue;
+    
+    // Check if we're still in settling time (skip peak detection)
+    bool inSettlingTime = (millis() - autotuneStartTime) < AUTOTUNE_SETTLING_TIME_MS;
+    
+    // Detect peaks (local maxima and minima) with noise band
+    bool isPeak = false;
+    
+    Serial.print("inSettlingTime: ");
+    Serial.print(inSettlingTime); 
+    Serial.print(", LastValue: ");
+    Serial.print(atLastValue);
+    Serial.print(", inputValue: ");
+    Serial.print(inputValue);
+    Serial.print(", risingEdge: ");
+    Serial.println(atRisingEdge);
+
+
+    if (inSettlingTime) { // during initial settling time, just update last value
+        atLastValue = inputValue;
+    } else {
+        if (atRisingEdge) {
+            // Looking for a maximum (peak high)
+            if (inputValue < (atLastValue - AUTOTUNE_PEAK_NOISE_BAND)) {
+                // Started falling, we just passed a peak
+                isPeak = true;
+                if (atLastValue > atPeakHigh) {
+                    atPeakHigh = atLastValue;
+                }
+                atRisingEdge = false;
+                
+                if (serialOutput) {
+                    Serial.print("Peak HIGH detected: ");
+                    Serial.print(atLastValue);
+                    Serial.println("°C");
+                }
+            }
+
+            if (inputValue > atLastValue) {
+                // Only update on higher values
+                atLastValue = inputValue;
+            }
+
+        } else {
+            // Looking for a minimum (peak low)
+            if (inputValue > (atLastValue + AUTOTUNE_PEAK_NOISE_BAND)) {
+                // Started rising, we just passed a valley
+                isPeak = true;
+                if (atLastValue < atPeakLow || atPeakLow == 0) {
+                    atPeakLow = atLastValue;
+                }
+                atRisingEdge = true;
+                
+                if (serialOutput) {
+                    Serial.print("Peak LOW detected: ");
+                    Serial.print(atLastValue);
+                    Serial.println("°C");
+                }
+            }
+
+            if (inputValue < atLastValue) {
+                // Only update on lower values
+                atLastValue = inputValue;
+            }
+        }
+    }
+    
+    // Record peak time
+    if (isPeak && atPeakCount < 10) {
+        atPeakTimes[atPeakCount] = millis();
+        atPeakCount++;
+    }
+    
+    // Relay control: switch output based on error
+    if (error > AUTOTUNE_SETPOINT_BAND) {
+        // Below setpoint - turn ON
+        atRelayState = true;
+        *output = AUTOTUNE_RELAY_OUTPUT;
+    } else if (error < -AUTOTUNE_SETPOINT_BAND) {
+        // Above setpoint - turn OFF or reduce
+        atRelayState = false;
+        *output = 0.0;
+    }
+    // Within noise band - maintain current state
+    
+    
+    // After enough cycles, calculate PID parameters
+    if (atPeakCount >= (AUTOTUNE_MIN_CYCLES * 2)) {
+        // Calculate average period (time between same-type peaks)
+        // Need at least 2 complete cycles (4 peaks minimum)
+        double totalPeriod = 0;
+        int periodCount = 0;
+        
+        // Calculate periods between alternating peaks (full oscillation cycles)
+        for (int i = 2; i < atPeakCount; i++) {
+            unsigned long period = atPeakTimes[i] - atPeakTimes[i-2];
+            totalPeriod += period;
+            periodCount++;
+        }
+        
+        if (periodCount > 0) {
+            autotuneResults.Pu = (totalPeriod / periodCount) / 1000.0; // Convert to seconds
+            
+            // Calculate amplitude of oscillation
+            double amplitude = (atPeakHigh - atPeakLow) / 2.0;
+            
+            if (amplitude < AUTOTUNE_SETPOINT_BAND) {
+                autotuneState = AUTOTUNE_FAILED_NO_OSCILLATION;
+                *output = 0;
+                if (serialOutput) {
+                    Serial.println("Auto-tune FAILED: Insufficient oscillation amplitude");
+                    Serial.print("Amplitude: ");
+                    Serial.print(amplitude);
+                    Serial.print("°C (need > ");
+                    Serial.print(AUTOTUNE_SETPOINT_BAND);
+                    Serial.println("°C)");
+                }
+                return;
+            }
+            
+            // Calculate ultimate gain (Ku)
+            // Ku = (4 * d) / (π * a)
+            // where d = relay output amplitude (half the peak-to-peak swing), a = oscillation amplitude
+            autotuneResults.Ku = (2.0 * AUTOTUNE_RELAY_OUTPUT ) / (3.14159 * amplitude);
+            
+            // Ziegler-Nichols PID tuning rules (classic)
+            // Kp = 0.6 * Ku
+            // Ki = 1.2 * Ku / Pu
+            // Kd = 0.075 * Ku * Pu
+            autotuneResults.Kp = 0.6 * autotuneResults.Ku;
+            autotuneResults.Ki = 1.2 * autotuneResults.Ku / autotuneResults.Pu;
+            autotuneResults.Kd = 0.075 * autotuneResults.Ku * autotuneResults.Pu;
+            autotuneResults.isValid = true;
+            
+            autotuneState = AUTOTUNE_SUCCESS;
+            *output = 0;
+            
+            if (serialOutput) {
+                Serial.println("\n=== Auto-Tune COMPLETE ===");
+                Serial.print("Ultimate Gain (Ku): ");
+                Serial.println(autotuneResults.Ku, 4);
+                Serial.print("Ultimate Period (Pu): ");
+                Serial.print(autotuneResults.Pu, 2);
+                Serial.println(" seconds");
+                Serial.print("Oscillation amplitude: ");
+                Serial.print(amplitude, 2);
+                Serial.println("°C");
+                Serial.print("Peak High: ");
+                Serial.print(atPeakHigh, 2);
+                Serial.println("°C");
+                Serial.print("Peak Low: ");
+                Serial.print(atPeakLow, 2);
+                Serial.println("°C");
+                Serial.println("\nCalculated PID parameters (Ziegler-Nichols):");
+                Serial.print("Kp: ");
+                Serial.println(autotuneResults.Kp, 4);
+                Serial.print("Ki: ");
+                Serial.println(autotuneResults.Ki, 4);
+                Serial.print("Kd: ");
+                Serial.println(autotuneResults.Kd, 4);
+                Serial.println("=========================\n");
+            }
+        }
+    }
+}
+

--- a/diyp-controller/dp_pid.h
+++ b/diyp-controller/dp_pid.h
@@ -3,21 +3,59 @@ diyPresso PID controller
 (c) 2025 diyPresso
 
 Loosely based on the powerbroker2/ArduPID libary 
+
+PID controller for the diyPresso machines. Supports static and dynamic feed forward. 
+
+Dynamic feed forward (DFF) is calculated based on the reservoir weight. The water flowing out of
+the reservoir will be needed to be heated to the set temperature, so the power needed to
+heat this water is calculated and added to the output.
+
+The calculation is as follows:
+1) During a cycle the amount of water flowing into the boiler is measured (Δw in grams).
+The temperature difference between the (assumed) reservoir/inflow temperature and the set
+temperature is calculated. Using the specific heat capacity of water at 95°C (c = 4.21 J/g°C)
+the energy needed to heat this water to the set temperature is calculated (ΔE in Joules).
+Δw must be greater than 0 and is limited to 12 grams per second to avoid excessive power requests.
+There is a ratio factor to adjust the amount of dynamic feed forward used.
+
+ΔE = Δw * c * (T_set - T_inflow) * dffRatio
+
+2) The energy needed (ΔE) is added to the Energy stock pile (E_ff in Joules).
+E_ff = E_ff + ΔE
+
+3) The energy stock pile is converted to a power request (P_ff in Watts) by dividing the
+energy by the estimated sample time in seconds (Δt in seconds).
+P_ff can not be greater than the maximum boiler power (P_boiler in Watts) minus
+the static feed forward.
+
+P_ff = min(E_ff / Δt,  P_boiler * (1 - staticFeedForward))
+
+4) At the end of a cycle, the feedforward energy stock pile is reduced by the actual amount of energy
+used.
+
+E_ff = E_ff - (P_ff * Δt_actual)
+
+
 */
 
 #ifndef ARDUPID_H
 #define ARDUPID_H
 
 #include <Arduino.h>
+#include "dp_reservoir.h"
+#include "dp_brew.h"
 
-//#define PID_DEBUG
+#define MAX_FLOW_RATE_G_PER_MS 0.012 // maximum flow rate in grams per millisecond for dynamic feed forward calculation (12 g/s)
+#define SPECIFIC_HEAT_CAPACITY_WATER 4.21 // specific heat capacity of water in J/g°C, 95 °C
+#define DFF_ENERGY_STOCK_PILE_MAX_MS 60000 // maximum energy stock pile in milliseconds (times boiler power)
+#define DFF_ENERGY_STOCK_PILE_DECAY 0.90 // decay factor for energy stock pile per cycle
 
 class DpPID
 {
 public:
     DpPID() {};
 
-    void begin(double *input, double *output, double *setpoint, const double &p, const double &i, const double &d, const double &feedForward, const unsigned int &minSamplePeriodMs);
+    void begin(double *input, double *output, double *setpoint, const double &p, const double &i, const double &d, const double &feedForward, const bool &dynamicFeedForwardEnabled, const unsigned int &minSamplePeriodMs, Reservoir *reservoir = nullptr);
 
     void start();
     void reset();
@@ -26,8 +64,11 @@ public:
     void setWindUpLimits(const double& min, const double& max);
     //void setDeadBand(const double& min, const double& max);
     void setCoefficients(const double& p, const double& i, const double& d);
-    void setFeedForward(const double& feedForward);
+    void setFeedForward(const double& feedForward, const bool& dynamicFeedForwardEnabled = false);
     void setSampleTime(const unsigned int& minSamplePeriodMs);
+    
+    void setSerialOutput(const bool& enabled) { serialOutput = enabled; }
+    bool getSerialOutput() const { return serialOutput; }
 
     double P() {return termP;}
     double I() {return termI;}
@@ -36,22 +77,35 @@ public:
     void printToSerial();
 
 protected:
+    double calculateFeedForward();
+
+    bool serialOutput = false; // enable/disable serial debug output
+
     double* input;
     double* output;
     double* setpoint;
-    double Kp, Ki, Kd; // thee coefficients for the proportional, integral, and derivative terms 
-    double feedForward;
+    double Kp, Ki, Kd; // the coefficients for the proportional, integral, and derivative terms 
     double termP, termI, termD; // the calculated PID terms
     double unconstrainedOutput;
     double curError = 0, curInput = 0;
     double lastError = 0, lastSetpoint = 0, lastInput = 0;
-    //double deadBandMin, deadBandMax;
     double windUpMin = -100, windUpMax = 5;
     double outputMin = 0, outputMax = 100;
-    unsigned int minSamplePeriodMs = 0;
+    unsigned int minSamplePeriodMs = 1;
     unsigned long lastTime = 0;
-    unsigned long curSampleTimeMs = 0;
-    //bool modeType;
+    unsigned long curSampleTimeMs = 1000;
+
+    double staticFeedForward = 0;  // set, 0-100 percentage of boiler power
+    double dynamicFeedForward = 0; // calculated dynamic feed forward, 0-100 percentage of boiler power
+    bool dynamicFeedForwardEnabled = false;
+    unsigned long lastDynamicFeedForwardTime = 0;
+
+    Reservoir* reservoir; // reservoir object for dynamic feed forward
+    double previousReservoirWeight = 0; // previous weight for dynamic feed forward in grams
+    double boilerPowerKiloWatt = 1.250; // boiler power (in kilowatt as it will be multiplied with sample time in ms)
+    double dffRatio = 0.8; // Adjustable ratio for dynamic feed forward
+    double dffEnergyStockPile = 0; // Energy stock pile for dynamic feed forward in Joules
+
 };
 
 

--- a/diyp-controller/dp_pid.h
+++ b/diyp-controller/dp_pid.h
@@ -18,7 +18,7 @@ the energy needed to heat this water to the set temperature is calculated (ΔE i
 Δw must be greater than 0 and is limited to 12 grams per second to avoid excessive power requests.
 There is a ratio factor to adjust the amount of dynamic feed forward used.
 
-ΔE = Δw * c * (T_set - T_inflow) * dffRatio
+ΔE = Δw * c * (T_set - T_inflow) * dffFactor
 
 2) The energy needed (ΔE) is added to the Energy stock pile (E_ff in Joules).
 E_ff = E_ff + ΔE
@@ -103,7 +103,7 @@ protected:
     Reservoir* reservoir; // reservoir object for dynamic feed forward
     double previousReservoirWeight = 0; // previous weight for dynamic feed forward in grams
     double boilerPowerKiloWatt = 1.250; // boiler power (in kilowatt as it will be multiplied with sample time in ms)
-    double dffRatio = 0.8; // Adjustable ratio for dynamic feed forward
+    double dffFactor = 0.90; // Adjustable factor for dynamic feed forward
     double dffEnergyStockPile = 0; // Energy stock pile for dynamic feed forward in Joules
 
 };

--- a/diyp-controller/dp_pid.h
+++ b/diyp-controller/dp_pid.h
@@ -16,7 +16,7 @@ The temperature difference between the (assumed) reservoir/inflow temperature an
 temperature is calculated. Using the specific heat capacity of water at 95°C (c = 4.21 J/g°C)
 the energy needed to heat this water to the set temperature is calculated (ΔE in Joules).
 Δw must be greater than 0 and is limited to 12 grams per second to avoid excessive power requests.
-There is a ratio factor to adjust the amount of dynamic feed forward used.
+There is a factor (dffFactor) to adjust the amount of dynamic feed forward, to tune and to prevent overshoot.
 
 ΔE = Δw * c * (T_set - T_inflow) * dffFactor
 
@@ -93,6 +93,7 @@ public:
     void setWindUpLimits(const double& min, const double& max);
     void setCoefficients(const double& p, const double& i, const double& d);
     void setFeedForward(const double& feedForward, const bool& dynamicFeedForwardEnabled = false);
+    void setDynamicFeedForwardFactorPct(const double& factor); // In percentage (0.0 - 100.0%)
     void setSampleTime(const unsigned int& minSamplePeriodMs);
     
     void setSerialOutput(const bool& enabled) { serialOutput = enabled; }
@@ -146,7 +147,6 @@ protected:
     autotune_state_t autotuneState = AUTOTUNE_IDLE;
     unsigned long autotuneStartTime = 0;
     AutoTuneResults autotuneResults;
-    
     bool atRelayState = false;      // Current relay state (high/low)
     double atPeakHigh = 0;          // Highest peak temperature
     double atPeakLow = 0;           // Lowest peak temperature  
@@ -154,9 +154,6 @@ protected:
     int atPeakCount = 0;            // Number of peaks detected
     double atLastValue = 0;         // Previous input value
     bool atRisingEdge = true;       // Tracking if we're rising or falling
-
-
-
 };
 
 

--- a/diyp-controller/dp_pid.h
+++ b/diyp-controller/dp_pid.h
@@ -50,6 +50,35 @@ E_ff = E_ff - (P_ff * Δt_actual)
 #define DFF_ENERGY_STOCK_PILE_MAX_MS 60000 // maximum energy stock pile in milliseconds (times boiler power)
 #define DFF_ENERGY_STOCK_PILE_DECAY 0.90 // decay factor for energy stock pile per cycle
 
+// Auto-tune parameters
+#define AUTOTUNE_RELAY_OUTPUT 10.0 // Relay output amplitude (% of max power)
+#define AUTOTUNE_MIN_CYCLES 3 // Minimum number of oscillation cycles to measure
+#define AUTOTUNE_TIMEOUT_MS 1800000 // Auto-tune timeout (30 minutes)
+#define AUTOTUNE_SETPOINT_BAND 0.3 // Band around setpoint for relay switching (+/- degC)
+#define AUTOTUNE_PEAK_NOISE_BAND 0.08 // Noise band for peak detection (+/- degC)
+#define AUTOTUNE_SETTLING_TIME_MS 25000 // Initial settling time before peak detection (25 seconds)
+
+// Auto-tune results structure
+struct AutoTuneResults {
+    double Kp;
+    double Ki;
+    double Kd;
+    double Ku;  // Ultimate gain (for reference)
+    double Pu;  // Ultimate period in seconds (for reference)
+    bool isValid;
+    
+    AutoTuneResults() : Kp(0), Ki(0), Kd(0), Ku(0), Pu(0), isValid(false) {}
+};
+
+typedef enum {
+    AUTOTUNE_IDLE,
+    AUTOTUNE_RUNNING,
+    AUTOTUNE_SUCCESS,
+    AUTOTUNE_FAILED_TIMEOUT,
+    AUTOTUNE_FAILED_NO_OSCILLATION
+} autotune_state_t;
+
+
 class DpPID
 {
 public:
@@ -62,13 +91,19 @@ public:
     void compute();
     void setOutputLimits(const double& min, const double& max);
     void setWindUpLimits(const double& min, const double& max);
-    //void setDeadBand(const double& min, const double& max);
     void setCoefficients(const double& p, const double& i, const double& d);
     void setFeedForward(const double& feedForward, const bool& dynamicFeedForwardEnabled = false);
     void setSampleTime(const unsigned int& minSamplePeriodMs);
     
     void setSerialOutput(const bool& enabled) { serialOutput = enabled; }
     bool getSerialOutput() const { return serialOutput; }
+
+    // Auto-tune functions
+    void startAutoTune();
+    void cancelAutoTune();
+    autotune_state_t getAutoTuneState() const { return autotuneState; }
+    bool isAutoTuning() const { return autotuneState == AUTOTUNE_RUNNING; }
+    AutoTuneResults getAutoTuneResults() const;
 
     double P() {return termP;}
     double I() {return termI;}
@@ -78,6 +113,7 @@ public:
 
 protected:
     double calculateFeedForward();
+    void processAutoTune();
 
     bool serialOutput = false; // enable/disable serial debug output
 
@@ -105,6 +141,21 @@ protected:
     double boilerPowerKiloWatt = 1.250; // boiler power (in kilowatt as it will be multiplied with sample time in ms)
     double dffFactor = 0.90; // Adjustable factor for dynamic feed forward
     double dffEnergyStockPile = 0; // Energy stock pile for dynamic feed forward in Joules
+
+    // Auto-tune variables
+    autotune_state_t autotuneState = AUTOTUNE_IDLE;
+    unsigned long autotuneStartTime = 0;
+    AutoTuneResults autotuneResults;
+    
+    bool atRelayState = false;      // Current relay state (high/low)
+    double atPeakHigh = 0;          // Highest peak temperature
+    double atPeakLow = 0;           // Lowest peak temperature  
+    unsigned long atPeakTimes[10];  // Store times of peaks
+    int atPeakCount = 0;            // Number of peaks detected
+    double atLastValue = 0;         // Previous input value
+    bool atRisingEdge = true;       // Tracking if we're rising or falling
+
+
 
 };
 

--- a/diyp-controller/dp_reservoir.cpp
+++ b/diyp-controller/dp_reservoir.cpp
@@ -21,20 +21,50 @@ Reservoir::Reservoir()
 /// @brief Read weight sensor and store the scaled weight value
 void Reservoir::read()
 {
-  scale.wait_ready_timeout(1);
+  double new_gross_weight;
+
+  // scale.wait_ready_timeout(1); //removed to make non-blocking, don't think this is needed
   _readings += 1;
-  if (_readings > 10)
+  
+  if (_readings > 50)
     _error = RESERVOIR_ERROR_NO_READINGS;
+  
   if ( scale.is_ready() )
   {
-    _readings = 0;
-    _weight = scale.read();
-    // DEBUG: Serial.println(_weight);
-    _weight = (_weight - _offset) / ( (1.0+_trim/100.0) * _scale);
-    double w = weight();
-    if ( w > RESERVOIR_CAPACITY + 100.0 ) _error = RESERVOIR_ERROR_OUT_OF_RANGE;
-    if ( w < -100.0 ) _error = RESERVOIR_ERROR_NEGATIVE;
-  }
+  
+    // read the weight from the sensor and calculate the gross weight
+    new_gross_weight = (scale.read() - _offset) / ( _scale);
+
+    // Serial.print("nr of readings: ");
+    // Serial.println(_readings);
+     _readings = 0;
+
+    // simple deglitcher: only accept new reading if within _glitch_limit grams of previous reading, or on 3 consecutive glitches, or on first reading (-1)
+    if  (abs(new_gross_weight - _weight_gross) > _glitch_limit && _deglitched < 3 && _deglitched > -1 )
+    {
+      _deglitched += 1;  
+      Serial.print("!!!! Deglitched reservoir reading. New: "); // TODO: disable debug
+      Serial.print(new_gross_weight);
+      Serial.print(" old: ");
+      Serial.print(_weight_gross);
+      Serial.print(" diff: ");
+      Serial.print(abs(new_gross_weight - _weight_gross));
+      Serial.print(" deglitched count: ");
+      Serial.println(_deglitched);
+    }
+    else
+    {
+      _deglitched = 0;
+      _weight_gross = new_gross_weight;
+      // Serial.println("Not deglitched");
+    }
+
+    _weight_net = (_weight_gross / (1.0 + _trim / 100.0)) - _tare;
+    if ( _weight_net > RESERVOIR_CAPACITY + 100.0 ) _error = RESERVOIR_ERROR_OUT_OF_RANGE;
+    if ( _weight_net < -100.0 ) _error = RESERVOIR_ERROR_NEGATIVE;
+  } 
+  
+
 }
 
 const char *Reservoir::get_error_text()

--- a/diyp-controller/dp_reservoir.h
+++ b/diyp-controller/dp_reservoir.h
@@ -19,21 +19,24 @@ class Reservoir
     private:
       double _level = 0.0;  // level [0..100%]
       double _tare = 0.0;   // tare weight (when empty) [gr]
-      double _weight = 0.0; // current gross weight [gr]
+      double _weight_gross = 0.0; // current gross weight [gr]
+      double _weight_net = 0.0; // current net weight [gr]
       double _offset = 240000.0; // zero level offset [adc_units]
       double _scale = 427.4;     // scale [adc_units/gram]
       double _trim = 0.0;        // scale trim to match calibrated weight [%]
       int _readings = 0;         // number of readings without measurement
+      double _glitch_limit = 50.0; // maximum change in weight between readings to be accepted [grams]
+      int _deglitched = -1;      // number of deglitched readings, -1 to indicate first reading
       reservoir_error_t _error = RESERVOIR_ERROR_NONE;
       void read();  // update the internal state, based on weight measurement
     public:
       Reservoir();
       double level() { return max(0, min(100.0 * ( weight() / RESERVOIR_CAPACITY), 100.0)); } // level [in %]
-      double weight() { read(); return _weight - _tare; } // net weight
+      double weight() { read(); return _weight_net; } // net weight
       double get_tare() { return _tare; }
       void set_tare(double t) { _tare = t; clear_error(); }
       void set_trim(double t) { _trim = t; }
-      void tare() { read(); _tare = _weight - RESERVOIR_CAPACITY; clear_error(); } // note: tare when reservoir is full
+      void tare() { read(); _tare = _weight_gross - RESERVOIR_CAPACITY; clear_error(); } // note: tare when reservoir is full
       bool is_empty() { return level() < RESERVOIR_EMPTY_LEVEL; } // return true if under empty limit
       bool is_almost_empty() { return level() < RESERVOIR_ALMOST_EMPTY_WARNING_LEVEL; } // return true if under warning limit
       bool is_error() { return _error != RESERVOIR_ERROR_NONE; }

--- a/diyp-controller/dp_reservoir.h
+++ b/diyp-controller/dp_reservoir.h
@@ -27,6 +27,7 @@ class Reservoir
       int _readings = 0;         // number of readings without measurement
       double _glitch_limit = 50.0; // maximum change in weight between readings to be accepted [grams]
       int _deglitched = -1;      // number of deglitched readings, -1 to indicate first reading
+      double _outflow_temp = 35.0; // temperature of the water leaving the reservoir in °C
       reservoir_error_t _error = RESERVOIR_ERROR_NONE;
       void read();  // update the internal state, based on weight measurement
     public:
@@ -39,6 +40,8 @@ class Reservoir
       void tare() { read(); _tare = _weight_gross - RESERVOIR_CAPACITY; clear_error(); } // note: tare when reservoir is full
       bool is_empty() { return level() < RESERVOIR_EMPTY_LEVEL; } // return true if under empty limit
       bool is_almost_empty() { return level() < RESERVOIR_ALMOST_EMPTY_WARNING_LEVEL; } // return true if under warning limit
+      double outflowTemp() { return _outflow_temp; } // get outflow temperature
+      void setOutflowTemp(double temp) { _outflow_temp = temp; } // set outflow temperature
       bool is_error() { return _error != RESERVOIR_ERROR_NONE; }
       reservoir_error_t error() { return _error; }
       const char *get_error_text();

--- a/diyp-controller/dp_serial.cpp
+++ b/diyp-controller/dp_serial.cpp
@@ -16,6 +16,14 @@
     or e.g. PUT settings temperature=98.00,commissioningDone=1
     - GET serialOutputConfig
     - PUT serialOutputConfig DP_PID_STATE=1
+    - GET boiler
+    - PUT boiler powerControlMode=STATIC,staticPower=5.0
+    - PUT boiler powerControlMode=PID
+    - GET boilerPidAutotune
+    - PUT boilerPidAutotune start
+    - PUT boilerPidAutotune cancel
+    - PUT boilerPidAutotune apply
+
 
 */
 
@@ -25,6 +33,7 @@
 #include "dp_brew.h"
 #include "dp_boiler.h"
 #include "dp_reservoir.h"
+#include "dp_pid.h"
 
 //initialize the class
 DpSerial dpSerial(115200);
@@ -91,6 +100,14 @@ void DpSerial::receive() {
         get_serial_output_config();
     } else if (receivedData.startsWith("PUT serialOutputConfig ")) {
         put_serial_output_config(receivedData.substring(String("PUT serialOutputConfig ").length()));
+    } else if (receivedData.startsWith("GET boilerPidAutotune")) {
+        get_boiler_pid_autotune();
+    } else if (receivedData.startsWith("PUT boilerPidAutotune ")) {
+        put_boiler_pid_autotune(receivedData.substring(String("PUT boilerPidAutotune ").length()));
+    } else if (receivedData.startsWith("GET boiler")) {
+        get_boiler();
+    } else if (receivedData.startsWith("PUT boiler ")) {
+        put_boiler(receivedData.substring(String("PUT boiler ").length()));
     } else {
         send("unknown command: " + receivedData);
     }
@@ -160,5 +177,129 @@ void DpSerial::put_serial_output_config(String value) {
         }
     } else {
         send("PUT serialOutputConfig NOK, unknown key: " + value);
+    }
+}
+
+void DpSerial::get_boiler() {
+    send("powerControlMode=" + boilerController.get_power_control_mode_str());
+    send("staticPower=" + String(boilerController.get_power_static(), 2));
+    send("GET boiler OK");
+}
+
+void DpSerial::put_boiler(String value) {
+    // Parse key-value pairs separated by commas
+    // Example: "powerControlMode=STATIC,staticPower=5.0"
+    
+    value.trim();
+    bool success = true;
+    String errorMsg = "";
+    
+    int startPos = 0;
+    while (startPos < value.length()) {
+        int commaPos = value.indexOf(',', startPos);
+        if (commaPos == -1) {
+            commaPos = value.length();
+        }
+        
+        String pair = value.substring(startPos, commaPos);
+        pair.trim();
+        
+        int equalsPos = pair.indexOf('=');
+        if (equalsPos == -1) {
+            success = false;
+            errorMsg = "Invalid format, missing '=' in: " + pair;
+            break;
+        }
+        
+        String key = pair.substring(0, equalsPos);
+        String val = pair.substring(equalsPos + 1);
+        key.trim();
+        val.trim();
+        key.toLowerCase();
+        
+        if (key == "powercontrolmode") {
+            if (!boilerController.set_power_control_mode_str(val)) {
+                success = false;
+                errorMsg = "Invalid powerControlMode value: " + val;
+                break;
+            }
+        } else if (key == "staticpower") {
+            double power = val.toDouble();
+            if (power < 0.0 || power > 100.0) {
+                success = false;
+                errorMsg = "staticPower must be between 0.0 and 100.0, got: " + val;
+                break;
+            }
+            boilerController.set_power_static(power);
+        } else {
+            success = false;
+            errorMsg = "Unknown key: " + key;
+            break;
+        }
+        
+        startPos = commaPos + 1;
+    }
+    
+    if (success) {
+        send("PUT boiler OK");
+    } else {
+        send("PUT boiler NOK, " + errorMsg);
+    }
+}
+
+void DpSerial::get_boiler_pid_autotune() {
+    autotune_state_t state = boilerController.getAutoTuneState();
+    String stateStr;
+    
+    switch(state) {
+        case AUTOTUNE_IDLE: stateStr = "IDLE"; break;
+        case AUTOTUNE_RUNNING: stateStr = "RUNNING"; break;
+        case AUTOTUNE_SUCCESS: stateStr = "SUCCESS"; break;
+        case AUTOTUNE_FAILED_TIMEOUT: stateStr = "FAILED_TIMEOUT"; break;
+        case AUTOTUNE_FAILED_NO_OSCILLATION: stateStr = "FAILED_NO_OSCILLATION"; break;
+        default: stateStr = "UNKNOWN"; break;
+    }
+    
+    send("state=" + stateStr);
+    
+    // If complete, also send the results
+    if (state == AUTOTUNE_SUCCESS) {
+        AutoTuneResults results = boilerController.getAutoTuneResults();
+        if (results.isValid) {
+            send("Kp=" + String(results.Kp, 3));
+            send("Ki=" + String(results.Ki, 3));
+            send("Kd=" + String(results.Kd, 3));
+            send("Ku=" + String(results.Ku, 3));
+            send("Pu=" + String(results.Pu, 3));
+        } else {
+            send("isValid=false");
+        }
+    }
+    
+    send("GET boilerPidAutotune OK");
+}
+
+void DpSerial::put_boiler_pid_autotune(String value) {
+    value.trim();
+    value.toLowerCase();
+    
+    if (value == "start") {
+        // Start auto-tune with default relay amplitude
+        boilerController.startAutoTune();
+        send("PUT boilerPidAutotune OK, Auto-tune started");
+    } else if (value == "cancel") {
+        boilerController.cancelAutoTune();
+        send("PUT boilerPidAutotune OK, Auto-tune cancelled");
+    } else if (value == "apply") {
+        AutoTuneResults results = boilerController.getAutoTuneResults();
+        if (results.isValid) {
+            boilerController.set_pid(results.Kp, results.Ki, results.Kd); //TODO: store in settings.
+            send("PUT boilerPidAutotune OK, Applied Kp=" + String(results.Kp, 3) + 
+                 " Ki=" + String(results.Ki, 3) + " Kd=" + String(results.Kd, 3));
+        } else {
+            send("PUT boilerPidAutotune NOK, No valid results to apply");
+        }
+    } else {
+        send("PUT boilerPidAutotune NOK, Unknown command (use: start/cancel/apply)");
     }
 }

--- a/diyp-controller/dp_serial.cpp
+++ b/diyp-controller/dp_serial.cpp
@@ -12,7 +12,7 @@
     supported commands:
     - GET info
     - GET settings
-    - PUT settings temperature=98.50,P=7.00,I=0.30,D=80.00,ff_heat=3.00,ff_ready=10.00,ff_brew=80.00,tareWeight=0.00,trimWeight=0.00,preInfusionTime=3.00,infuseTime=1.00,extractTime=25.00,extractionWeight=0.00,commissioningDone=1,shotCounter=5,wifiMode=0
+    - PUT settings temperature=98.50,P=7.00,I=0.30,D=80.00,dffFactorPct=90.00,ffHeat=3.00,ffReady=10.00,tareWeight=0.00,trimWeight=0.00,preInfusionTime=3.00,infusionTime=1.00,extractionTime=25.00,extractionWeight=0.00,commissioningDone=1,shotCounter=5,wifiMode=0
     or e.g. PUT settings temperature=98.00,commissioningDone=1
     - GET serialOutputConfig
     - PUT serialOutputConfig DP_PID_STATE=1

--- a/diyp-controller/dp_serial.cpp
+++ b/diyp-controller/dp_serial.cpp
@@ -14,6 +14,8 @@
     - GET settings
     - PUT settings temperature=98.50,P=7.00,I=0.30,D=80.00,ff_heat=3.00,ff_ready=10.00,ff_brew=80.00,tareWeight=0.00,trimWeight=0.00,preInfusionTime=3.00,infuseTime=1.00,extractTime=25.00,extractionWeight=0.00,commissioningDone=1,shotCounter=5,wifiMode=0
     or e.g. PUT settings temperature=98.00,commissioningDone=1
+    - GET serialOutputConfig
+    - PUT serialOutputConfig DP_PID_STATE=1
 
 */
 
@@ -79,18 +81,19 @@ void DpSerial::receive() {
 
     receivedData = Serial.readStringUntil('\n');
 
-    //GET info
     if (receivedData.startsWith("GET info")) {
         send_info();
     } else if (receivedData.startsWith("GET settings")) {
         send_settings();
-    } else if (receivedData.startsWith("PUT settings "))
-    {
-        put_settings(receivedData.substring(String("SET settings ").length()));
+    } else if (receivedData.startsWith("PUT settings ")) {
+        put_settings(receivedData.substring(String("PUT settings ").length()));
+    } else if (receivedData.startsWith("GET serialOutputConfig")) {
+        get_serial_output_config();
+    } else if (receivedData.startsWith("PUT serialOutputConfig ")) {
+        put_serial_output_config(receivedData.substring(String("PUT serialOutputConfig ").length()));
+    } else {
+        send("unknown command: " + receivedData);
     }
-    
-
-    send("echo: " + receivedData);
 }
 
 void DpSerial::send_info() {
@@ -135,5 +138,27 @@ void DpSerial::put_settings(String value) {
     } else {
         send("PUT settings NOK, settings not saved, unknown error code when deserializing settings: " + String(res_deserialize));
     }
+}
 
+void DpSerial::get_serial_output_config() {
+    send("DP_PID_STATE=" + String(boilerController.get_serial_output() ? "1" : "0"));
+    send("GET serialOutputConfig OK");
+}
+
+void DpSerial::put_serial_output_config(String value) {
+    // Expecting a string like "DP_PID_STATE=1" or "DP_PID_STATE=0"
+    if (value.startsWith("DP_PID_STATE=")) {
+        String stateStr = value.substring(String("DP_PID_STATE=").length());
+        if (stateStr == "1") {
+            boilerController.set_serial_output(true);
+            send("PUT serialOutputConfig OK");
+        } else if (stateStr == "0") {
+            boilerController.set_serial_output(false);
+            send("PUT serialOutputConfig OK");
+        } else {
+            send("PUT serialOutputConfig NOK, invalid value for DP_PID_STATE: " + stateStr);
+        }
+    } else {
+        send("PUT serialOutputConfig NOK, unknown key: " + value);
+    }
 }

--- a/diyp-controller/dp_serial.h
+++ b/diyp-controller/dp_serial.h
@@ -21,6 +21,8 @@ class DpSerial {
     private:
         unsigned long _baudRate;
         void put_settings(String value);
+        void get_serial_output_config();
+        void put_serial_output_config(String value);
 };
 
 extern DpSerial dpSerial;

--- a/diyp-controller/dp_serial.h
+++ b/diyp-controller/dp_serial.h
@@ -23,6 +23,10 @@ class DpSerial {
         void put_settings(String value);
         void get_serial_output_config();
         void put_serial_output_config(String value);
+        void get_boiler();
+        void put_boiler(String value);
+        void get_boiler_pid_autotune();
+        void put_boiler_pid_autotune(String value);
 };
 
 extern DpSerial dpSerial;

--- a/diyp-controller/dp_settings.cpp
+++ b/diyp-controller/dp_settings.cpp
@@ -63,7 +63,7 @@ bool DpSettings::crc_is_valid(settings_t *s)
 /// @brief set all values to default in settings stuct
 void DpSettings::defaults()
 {
-    settings.version = 1;  // Update this if new fields are added to the settings structure to prevent incorrect reads
+    settings.version = 2;  // bumped: ff_brew removed, dff_factor added to struct
     settings.temperature = 98.0;
     settings.preInfusionTime = 3;
     settings.infusionTime = 1;
@@ -71,9 +71,9 @@ void DpSettings::defaults()
     settings.p = 6.2;
     settings.i = 0.08;
     settings.d = 70.0;
-    settings.ff_heat = 6.0;
-    settings.ff_ready = 6.0;
-    settings.ff_brew = 35.0;
+    settings.ffHeat = 6.0;
+    settings.ffReady = 6.0;
+    settings.dffFactorPct = 90.0;  // 90%
     settings.tareWeight = 0.0;
     settings.trimWeight = 0.0;
     settings.wifiMode = 0; // off=0
@@ -164,21 +164,15 @@ void DpSettings::apply()
   boilerController.set_temp(temperature());
 
   boilerController.set_pid(P(), I(), D());
-  boilerController.set_ff_heat(ff_heat());
-  boilerController.set_ff_ready(ff_ready());
-  boilerController.set_ff_brew(ff_brew());
+  boilerController.set_ffHeat(ffHeat());
+  boilerController.set_ffReady(ffReady());
+  boilerController.set_dffFactorPct(dffFactorPct());
 
   reservoir.set_trim(trimWeight());
   reservoir.set_tare(tareWeight());
-
   brewProcess.preInfuseTime = preInfusionTime();
   brewProcess.infuseTime = infusionTime();
   brewProcess.extractTime = extractionTime();
-
-  
-
-
-
 }
 
 String DpSettings::serialize() {
@@ -193,9 +187,9 @@ String DpSettings::serialize() {
     result += "p=" + String(settings.p) + "\n";
     result += "i=" + String(settings.i) + "\n";
     result += "d=" + String(settings.d) + "\n";
-    result += "ff_heat=" + String(settings.ff_heat) + "\n";
-    result += "ff_ready=" + String(settings.ff_ready) + "\n";
-    result += "ff_brew=" + String(settings.ff_brew) + "\n";
+    result += "dffFactorPct=" + String(settings.dffFactorPct) + "\n";
+    result += "ffHeat=" + String(settings.ffHeat) + "\n";
+    result += "ffReady=" + String(settings.ffReady) + "\n";
     result += "tareWeight=" + String(settings.tareWeight) + "\n";
     result += "trimWeight=" + String(settings.trimWeight) + "\n";
     result += "commissioningDone=" + String(settings.commissioningDone) + "\n";
@@ -206,7 +200,7 @@ String DpSettings::serialize() {
 
 
 /* receives a string, parses it and updates the settings. For example:
-temperature=98.50,P=7.00,I=0.30,D=80.00,ff_heat=3.00,ff_ready=10.00,ff_brew=80.00,tareWeight=0.00,trimWeight=0.00,preInfusionTime=3.00,infuseTime=1.00,extractTime=25.00,extractionWeight=0.00,commissioningDone=1,shotCounter=5,wifiMode=0
+temperature=98.50,P=7.00,I=0.30,D=80.00,dff_factor=90.00,ff_ready=10.00,ff_brew=80.00,tareWeight=0.00,trimWeight=0.00,preInfusionTime=3.00,infuseTime=1.00,extractTime=25.00,extractionWeight=0.00,commissioningDone=1,shotCounter=5,wifiMode=0
 
 can also be a subset of these values.
 
@@ -252,21 +246,24 @@ int DpSettings::deserialize(String serialized_settings) {
             I(value.toDouble());
         } else if (key == "d" || key == "D") {
             D(value.toDouble());
-        } else if (key == "ff_heat") {
-            ff_heat(value.toDouble());
-        } else if (key == "ff_ready") {
-            ff_ready(value.toDouble());
-        } else if (key == "ff_brew") {
-            ff_brew(value.toDouble());
+        } else if (key == "dffFactorPct") {
+            dffFactorPct(value.toDouble());
+        } else if (key == "ffHeat" || key == "ff_heat") {
+            ffHeat(value.toDouble());
+        } else if (key == "ffReady" || key == "ff_ready") {
+            ffReady(value.toDouble());
+        } else if (key == "ffBrew" || key == "ff_brew") {
+            // Deprecated: ignored
+            Serial.println("WARNING: ff_brew / ffBrew is deprecated and will be ignored.");
         } else if (key == "tareWeight") {
             tareWeight(value.toDouble());
         } else if (key == "trimWeight") {
             trimWeight(value.toDouble());
         } else if (key == "preInfusionTime") {
             preInfusionTime(value.toDouble());
-        } else if (key == "infusionTime" || key == "infuseTime") { // infuseTime is an depricated alias for infusionTime
+        } else if (key == "infusionTime" || key == "infuseTime") { // infuseTime is a deprecated alias for infusionTime
             infusionTime(value.toDouble());
-        } else if (key == "extractionTime" || key == "extractTime") { // extractTime is an depricated alias for extractionTime
+        } else if (key == "extractionTime" || key == "extractTime") { // extractTime is a deprecated alias for extractionTime
             extractionTime(value.toDouble());
         } else if (key == "extractionWeight") {
             extractionWeight(value.toDouble());
@@ -283,7 +280,7 @@ int DpSettings::deserialize(String serialized_settings) {
     }
 
     if (error < 0) {
-        load(); // discart updarte and restore settings from EEPROM on error
+        load(); // discard update and restore settings from EEPROM on error
     }
 
     return error;

--- a/diyp-controller/dp_settings.h
+++ b/diyp-controller/dp_settings.h
@@ -25,7 +25,7 @@ class DpSettings
             double infusionTime;
             double extractionTime;
             double extractionWeight;
-            double p, i, d, ff_heat, ff_ready, ff_brew;
+            double p, i, d, dffFactorPct, ffHeat, ffReady;
             double tareWeight;
             double trimWeight;
             int commissioningDone;
@@ -61,12 +61,13 @@ class DpSettings
         double I(double i) { return settings.i = min(20.0, max(i, 0.00)); }
         double D() { return settings.d; }
         double D(double d) { return settings.d = min(999.0, max(d, 0.0)); }
-        double ff_heat() { return settings.ff_heat; }
-        double ff_heat(double ff) { return settings.ff_heat = min(100.0, max(ff, 0.0)); }
-        double ff_ready() { return settings.ff_ready; }
-        double ff_ready(double ff) { return settings.ff_ready = min(100.0, max(ff, 0.0)); }
-        double ff_brew() { return settings.ff_brew; }
-        double ff_brew(double ff) { return settings.ff_brew = min(100.0, max(ff, 0.0)); }
+        double ffHeat() { return settings.ffHeat; }
+        double ffHeat(double ff) { return settings.ffHeat = min(100.0, max(ff, 0.0)); }
+        double ffReady() { return settings.ffReady; }
+        double ffReady(double ff) { return settings.ffReady = min(100.0, max(ff, 0.0)); }
+        double dffFactorPct() { return settings.dffFactorPct; }
+        double dffFactorPct(double dff) { return settings.dffFactorPct = min(200.0, max(dff, 0.0)); }
+
         double tareWeight() { return settings.tareWeight; }
         double tareWeight(double t) { return settings.tareWeight = min(2000.0, max(t, -2000.0)); }
         double trimWeight() { return settings.trimWeight; }

--- a/diyp-controller/dp_settings.h
+++ b/diyp-controller/dp_settings.h
@@ -60,7 +60,7 @@ class DpSettings
         double I() { return settings.i; }
         double I(double i) { return settings.i = min(20.0, max(i, 0.00)); }
         double D() { return settings.d; }
-        double D(double d) { return settings.d = min(200.0, max(d, 0.0)); }
+        double D(double d) { return settings.d = min(999.0, max(d, 0.0)); }
         double ff_heat() { return settings.ff_heat; }
         double ff_heat(double ff) { return settings.ff_heat = min(100.0, max(ff, 0.0)); }
         double ff_ready() { return settings.ff_ready; }

--- a/diyp-controller/dp_settings.h
+++ b/diyp-controller/dp_settings.h
@@ -60,7 +60,7 @@ class DpSettings
         double I() { return settings.i; }
         double I(double i) { return settings.i = min(20.0, max(i, 0.00)); }
         double D() { return settings.d; }
-        double D(double d) { return settings.d = min(100.0, max(d, 0.0)); }
+        double D(double d) { return settings.d = min(200.0, max(d, 0.0)); }
         double ff_heat() { return settings.ff_heat; }
         double ff_heat(double ff) { return settings.ff_heat = min(100.0, max(ff, 0.0)); }
         double ff_ready() { return settings.ff_ready; }


### PR DESCRIPTION
## Summary
Implements dynamic feed-forward factor control for improved temperture stability during brewing and tapping water from the boiler.
The Dynamic Feed Forward (DFF) heating power is calculated based on changes in reservoir weight. The water flowing out of the reservoir into the boiler will be needed to be heated to the set temperature, the power needed to heat this water is calculated and added to the output of the PID controller of the heater.

## Changes
- Dynamic Feed Forward based on resevoir weight changes inplemented in the PID controller
- The DFF factor (0-200%) used for tuning the dynamic feed forward has been added to the settings (incl menu)
- Temperature low-pass filtering (EMA) for sensor noise reduction
- Display rounding fix, e.g. at temperature of 95.99 now shows as 96.0 and  not 95.9)
- PID D parameter maximum increased to 999.0
- Settings struct version bumped to 2 (backwards compatible when updating using the client)
- As Alpha and Serial interface only: PID auto-tune using Relay/Ziegler-Nichols implemented, did not yet get desired results
- More consitent naming converntion for settings. 
- Static brew feed forward, ff_brew, is deprecated